### PR TITLE
[PLAYLOLLY] Add new callout types for docs theme

### DIFF
--- a/packages/nextra-theme-docs/package.json
+++ b/packages/nextra-theme-docs/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "@headlessui/react": "^1.4.2",
+    "@heroicons/react": "^1.0.5",
     "@mdx-js/react": "^2.0.0-rc.2",
     "@reach/skip-nav": "^0.16.0",
     "classnames": "^2.2.6",

--- a/packages/nextra-theme-docs/src/callout.tsx
+++ b/packages/nextra-theme-docs/src/callout.tsx
@@ -1,35 +1,61 @@
 import React from 'react'
+import {
+  InformationCircleIcon,
+  LightBulbIcon,
+  CheckCircleIcon,
+  ExclamationIcon,
+  XCircleIcon
+} from '@heroicons/react/solid/'
 
 const themes = {
-  default:
-    'bg-orange-50 border border-orange-100 text-orange-800 dark:text-orange-300 dark:bg-orange-400 dark:border-orange-400 dark:bg-opacity-20 dark:border-opacity-30',
-  error:
-    'bg-red-100 border border-red-200 text-red-900 dark:text-red-200 dark:bg-red-900 dark:bg-opacity-30 dark:border-opacity-30',
-  warning:
-    'bg-yellow-50 border border-yellow-100 text-yellow-900 dark:text-yellow-200 dark:bg-yellow-700 dark:bg-opacity-30'
+  info: {
+    className:
+      'bg-blue-100 text-blue-800 dark:text-blue-300 dark:bg-blue-200 dark:bg-opacity-10',
+    icon: <InformationCircleIcon className="w-5 h-5 mt-1" />
+  },
+  idea: {
+    className:
+      'bg-gray-100 text-gray-800 dark:text-gray-300 dark:bg-gray-200 dark:bg-opacity-10',
+    icon: <LightBulbIcon className="w-5 h-5 mt-1" />
+  },
+  success: {
+    className:
+      'bg-green-100 text-green-800 dark:text-green-300 dark:bg-green-200 dark:bg-opacity-10',
+    icon: <CheckCircleIcon className="w-5 h-5 mt-1" />
+  },
+  warning: {
+    className:
+      'bg-orange-100 text-orange-800 dark:text-orange-300 dark:bg-orange-200 dark:bg-opacity-10',
+    icon: <ExclamationIcon className="w-5 h-5 mt-1" />
+  },
+  error: {
+    className:
+      'bg-red-100 text-red-800 dark:text-red-300 dark:bg-red-200 dark:bg-opacity-10',
+    icon: <XCircleIcon className="w-5 h-5 mt-1" />
+  }
 }
 
 interface CalloutProps {
-  /** Callout Theme default to 'default'  */
+  /** Callout Theme default to 'default' **/
   type?: keyof typeof themes
-  /** default emoji 💡*/
+  /** no emoji by default **/
   emoji: string
 }
 
 const Callout: React.FC<CalloutProps> = ({
   children,
-  type = 'default',
-  emoji = '💡'
+  type = 'idea',
+  emoji
 }) => {
   return (
-    <div className={`${themes[type]} flex rounded-lg callout mt-6`}>
+    <div className={`${themes[type].className} flex rounded-lg callout mt-6`}>
       <div
         className="pl-3 pr-2 py-2 select-none text-xl"
         style={{
           fontFamily: '"Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"'
         }}
       >
-        {emoji}
+        {emoji || themes[type].icon}
       </div>
       <div className="pr-4 py-2">{children}</div>
     </div>

--- a/packages/nextra-theme-docs/tailwind.config.js
+++ b/packages/nextra-theme-docs/tailwind.config.js
@@ -36,6 +36,8 @@ module.exports = {
       gray: colors.gray,
       slate: colors.slate,
       neutral: colors.neutral,
+      blue: colors.blue,
+      green: colors.green,
       red: colors.red,
       orange: colors.orange,
       yellow: colors.yellow,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,6 +134,7 @@ importers:
   packages/nextra-theme-docs:
     specifiers:
       '@headlessui/react': ^1.4.2
+      '@heroicons/react': ^1.0.5
       '@mdx-js/react': ^2.0.0-rc.2
       '@reach/skip-nav': ^0.16.0
       '@types/flexsearch': ^0.7.2
@@ -150,6 +151,7 @@ importers:
       title: ^3.4.2
     dependencies:
       '@headlessui/react': 1.4.2_react-dom@17.0.2+react@17.0.2
+      '@heroicons/react': 1.0.5_react@17.0.2
       '@mdx-js/react': 2.0.0-rc.2_react@17.0.2
       '@reach/skip-nav': 0.16.0_react-dom@17.0.2+react@17.0.2
       classnames: 2.3.1
@@ -227,6 +229,14 @@ packages:
     dependencies:
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
+    dev: false
+
+  /@heroicons/react/1.0.5_react@17.0.2:
+    resolution: {integrity: sha512-UDMyLM2KavIu2vlWfMspapw9yii7aoLwzI2Hudx4fyoPwfKfxU8r3cL8dEBXOjcLG0/oOONZzbT14M1HoNtEcg==}
+    peerDependencies:
+      react: '>= 16'
+    dependencies:
+      react: 17.0.2
     dev: false
 
   /@mdx-js/mdx/2.0.0-rc.2:


### PR DESCRIPTION
Adds new callout types in the docs theme.

## Themes
### Idea
![Idea](https://i.imgur.com/cRin0Mt.png)

### Info
![Info](https://i.imgur.com/w517sgy.png)

### Success
![Success](https://i.imgur.com/8bxQjIh.png)

### Warning
![Warning](https://i.imgur.com/TVC4d00.png)

### Error
![Error](https://i.imgur.com/oCQX6s7.png)